### PR TITLE
Own design fixes

### DIFF
--- a/css/bootstrap-custom.css
+++ b/css/bootstrap-custom.css
@@ -96,7 +96,8 @@
 .form-group__error-message {
   padding: 4px 12px;
   display: none;
-  font-size: 16px;
+  font-size: 14px;
+  font-weight: 300;
   border-radius: 0 0 3px 3px;
   color: #FFF;
   background: #DC0015;
@@ -120,6 +121,7 @@
   }
   .form-group__error-message {
     position: absolute;
+    font-size: 16px;
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -362,6 +362,7 @@ footer {
 
 .footer__text {
   font-size: 15px;
+  font-weight: 300;
   color: #999;
   line-height: 20px;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -84,7 +84,7 @@ section {
     font-size: 32px;
   }
   h2 {
-    font-size: 16px;
+    font-size: 18px;
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -302,7 +302,7 @@ section {
 .result-card {
   max-width: 980px;
   margin: 40px auto;
-  padding: 40px;
+  padding: 24px 15px;
   display: flex;
   border-radius: 30px;
   background-color: #FFF;
@@ -320,6 +320,9 @@ section {
 @media (min-width: 768px) {
   .search-result-section {
     min-height: 512px;
+  }
+  .result-card {
+    padding: 40px;
   }
   .result-card__avatar {
     width: 63px;


### PR DESCRIPTION
This small PR attacks minor things which I noticed differently than the design.

**1 - Error Message on Mobile:** The `font-size` for mobile is `14px` not `16px` and the `font-weight` was lighter
**2 - Result Card Padding on Mobile:** The padding on mobile is a little bit tinier on mobile
**3 - H2:** The `H2` tag has a ligther `font-weight` on the spec.
**4 - Disclaimer:** The disclaimer section on the footer has a lighter `font-weight on the spec.